### PR TITLE
streaming src hostname

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -36,7 +36,7 @@ var app =
 app.custom = {
     url: "/api",
     serverBaseUrl: '/api', // (window.location.hostname === 'localhost' ? '/api' : '')
-    streamSrc: (window.location.hostname === 'localhost' ? 'http://localhost:4710/stream' : 'http://radio.canoo.com:4710/stream')
+    streamSrc: ('http://' + window.location.host + ':4710/stream')
 };
 
 app.filter('duration', function() {


### PR DESCRIPTION
If the application runs somewhere else than radio.canoo.com or the webpage is opened via the IP, the current implementation fails to provide a usable player. The change should solve it, but limits CanooRadio to have the client UI and the streaming server running on the same machine. 
Maybe we need to come up with a better attempt e.g. for development time, etc.